### PR TITLE
feat: search and filter albums

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
         <label for="artistId">Artist ID</label>
         <input id="artistId" type="text" placeholder="e.g., 112024" />
         <button id="loadAlbumsBtn" disabled>Load Albums</button>
+        <label for="searchQuery">Search Albums</label>
+        <input id="searchQuery" type="text" placeholder="Name, genre, or year" />
       </section>
 
       <section id="albums" aria-live="polite">

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,16 @@
+/**
+ * Filters albums by query matching name, genre, or year.
+ * @param {Array} albums
+ * @param {string} query
+ * @returns {Array} filtered albums
+ */
+export function filterAlbums(albums, query) {
+  const q = query.trim().toLowerCase();
+  if (!q) return albums;
+  return albums.filter(album => {
+    const name  = (album.strAlbum  || '').toLowerCase();
+    const genre = (album.strGenre  || '').toLowerCase();
+    const year  = String(album.intYearReleased || '').toLowerCase();
+    return name.includes(q) || genre.includes(q) || year.includes(q);
+  });
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,16 +1,28 @@
 /**
- * Filters albums by query matching name, genre, or year.
+ * Filters albums by matching name, genre, or year.
  * @param {Array} albums
  * @param {string} query
  * @returns {Array} filtered albums
  */
 export function filterAlbums(albums, query) {
   const q = query.trim().toLowerCase();
-  if (!q) return albums;
+  console.log("[filterAlbums] query:", q);
+
+  if (!q) {
+    // No search text → show everything
+    return albums;
+  }
+
   return albums.filter(album => {
-    const name  = (album.strAlbum  || '').toLowerCase();
-    const genre = (album.strGenre  || '').toLowerCase();
-    const year  = String(album.intYearReleased || '').toLowerCase();
-    return name.includes(q) || genre.includes(q) || year.includes(q);
+    const name  = (album.strAlbum         || "").toLowerCase();
+    const genre = (album.strGenre         || "").toLowerCase();
+    const year  = String(album.intYearReleased || "").toLowerCase();
+
+    // True if any field includes the query substring
+    return (
+      name.includes(q) ||
+      genre.includes(q) ||
+      year.includes(q)
+    );
   });
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -43,3 +43,11 @@ main { padding: 20px; display: grid; gap: var(--gap); }
 .error {
   color: #f87171; /* subtle red */
 }
+#searchQuery {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+}


### PR DESCRIPTION
## Summary
This PR implements Phase 3 of Music Playlist Manager:
- Adds a **Search Albums** input under the artist controls.
- Implements `filterAlbums(albums, query)` for case-insensitive matching on name, genre, or year.
- Wires live filtering in `app.js` to re-render album cards on each keystroke.
- Ensures an empty query restores the full cached album list.

---

## Changes
- **index.html**  
  • Inserted `<input id="searchQuery" placeholder="Name, genre, or year">` under the Artist ID controls.

- **styles/styles.css**  
  • Styled `#searchQuery` with padding, border, and responsive flex behavior.

- **src/utils.js**  
  • New file exporting `filterAlbums(albums, query)` utility.

- **src/app.js**  
  • Imported `filterAlbums` and stored fetched albums in `albumCache`.  
  • Added `searchInput` listener that calls `renderAlbums(filterAlbums(albumCache, query))`.

---

---
<img width="801" height="639" alt="image" src="https://github.com/user-attachments/assets/621779dc-72c3-4942-a355-195bf2a22962" />


