### PR TITLE
feat(api): Implement hybrid API layer: MusicBrainz homepage artists & TheAudioDB artist/album/track/global search

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -148,3 +148,21 @@ export async function fetchTracksByAlbumId(albumId) {
   // TheAudioDB returns an array of tracks, or null if not found
   return Array.isArray(data.track) ? data.track : [];
 }
+
+/**
+ * Global search: runs 3 parallel TheAudioDB calls (artist, album, track).
+ * @param {string} query - The search string.
+ * @returns {Promise<{artists: any[], albums: any[], tracks: any[]}>}
+ */
+export async function searchAllTheAudioDB(query) {
+  const [artistRes, albumRes, trackRes] = await Promise.all([
+    fetch(`${TADB_BASE_URL}/${TADB_API_KEY}/search.php?s=${encodeURIComponent(query)}`).then(r => r.json()),
+    fetch(`${TADB_BASE_URL}/${TADB_API_KEY}/searchalbum.php?a=${encodeURIComponent(query)}`).then(r => r.json()),
+    fetch(`${TADB_BASE_URL}/${TADB_API_KEY}/searchtrack.php?t=${encodeURIComponent(query)}`).then(r => r.json())
+  ]);
+  return {
+    artists: artistRes.artists || [],
+    albums: albumRes.album || [],
+    tracks: trackRes.track || []
+  };
+}

--- a/src/api.js
+++ b/src/api.js
@@ -109,15 +109,14 @@ export async function fetchAlbumsByArtistId(artistId) {
     console.log(`[cache] hit for ID=${artistId} (length=${cache[artistId].length})`);
     return cache[artistId];
   }
-  const url = `${BASE_URL}/${API_KEY}/album.php?i=${encodeURIComponent(artistId)}`;
-  
+  const url = `${TADB_BASE_URL}/${TADB_API_KEY}/album.php?i=${encodeURIComponent(artistId)}`;
   
   const response = await fetch(url);
 
   
   if (!response.ok) {
     // if for instance artistId invalid or server error (e.g., 404, 500)
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    throw new Error(`TheAudioDB error: ${response.status}`);
   }
 
   const data = await response.json();

--- a/src/api.js
+++ b/src/api.js
@@ -130,3 +130,21 @@ export async function fetchAlbumsByArtistId(artistId) {
 
   return albums;
 }
+
+/**
+ * Fetch tracks for a given album ID from TheAudioDB.
+ * @param {string} albumId - TheAudioDB album ID.
+ * @returns {Promise<any[]>} Resolves to an array of track objects.
+ */
+export async function fetchTracksByAlbumId(albumId) {
+  const url = `${TADB_BASE_URL}/${TADB_API_KEY}/track.php?m=${encodeURIComponent(albumId)}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`TheAudioDB error: ${response.status}`);
+  }
+
+  const data = await response.json();
+  // TheAudioDB returns an array of tracks, or null if not found
+  return Array.isArray(data.track) ? data.track : [];
+}

--- a/src/api.js
+++ b/src/api.js
@@ -17,6 +17,38 @@ async function throttleMusicBrainz() {
 }
 
 /**
+ * Fetch artists by genre from MusicBrainz.
+ * @param {string} genre - e.g. "rock"
+ * @param {number} limit - number of artists to fetch
+ * @returns {Promise<any[]>} Resolves to an array of artist objects.
+ */
+export async function getHomeArtistsMusicBrainz(genre = "rock", limit = 15) {
+  await throttleMusicBrainz(); // Wait if needed to respect rate limit
+  const url = `${MB_BASE_URL}/artist?query=tag:${encodeURIComponent(genre)}&fmt=json&limit=${limit}`;
+  const response = await fetch(url, {
+    headers: { "User-Agent": MB_USER_AGENT }
+  });
+  if (!response.ok) throw new Error(`MusicBrainz error: ${response.status}`);
+  const data = await response.json();
+  return data.artists || [];
+}
+
+/**
+ * Find TheAudioDB artist by name.
+ * @param {string} name - The artist name to search for.
+ * @returns {Promise<any|null>} Resolves to the artist object or null if not found.
+ */
+export async function getArtistByName_TheAudioDB(name) {
+  const url = `${TADB_BASE_URL}/${TADB_API_KEY}/search.php?s=${encodeURIComponent(name)}`;
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`TheAudioDB error: ${response.status}`);
+  const data = await response.json();
+  // TheAudioDB returns an array of artists, or null if not found
+  return data.artists ? data.artists[0] : null;
+}
+
+
+/**
  * Search for artists by name.
  * @param {string} artistName
  * @returns {Promise<any[]>} Resolves to an array of artist objects.

--- a/src/api.js
+++ b/src/api.js
@@ -49,54 +49,6 @@ export async function getArtistByName_TheAudioDB(name) {
 
 
 /**
- * Search for artists by name.
- * @param {string} artistName
- * @returns {Promise<any[]>} Resolves to an array of artist objects.
- */
-export async function searchArtistsByName(artistName) {
-  const url = `${BASE_URL}/${API_KEY}/search.php?s=${encodeURIComponent(artistName)}`;
-  
-  try {
-    const response = await fetch(url);
-    
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-    }
-
-    const data = await response.json();
-    console.log("[searchArtistsByName] parsed JSON:", data);
-
-    return data.artists || [];
-  } catch (error) {
-    console.error("Error searching artists:", error);
-    throw error;
-  }
-}
-
-/**
- * Fetch popular artists for the top picks section.
- * @returns {Promise<any[]>} Resolves to an array of popular artist objects.
- */
-export async function fetchPopularArtists() {
-  // Use some well-known artists as popular picks
-  const popularNames = ["Coldplay", "The Beatles", "Queen", "Michael Jackson", "Madonna"];
-  const artists = [];
-  
-  for (const name of popularNames) {
-    try {
-      const results = await searchArtistsByName(name);
-      if (results.length > 0) {
-        artists.push(results[0]);
-      }
-    } catch (error) {
-      console.warn(`Failed to fetch popular artist: ${name}`, error);
-    }
-  }
-  
-  return artists;
-}
-
-/**
  * Fetch albums for a given artist ID.
  * @param {string} artistId
  * @returns {Promise<any[]>} Resolves to an array of album objects.

--- a/src/api.js
+++ b/src/api.js
@@ -1,7 +1,20 @@
-// src/api.js
+// --- TheAudioDB constants ---
+export const TADB_BASE_URL = "https://www.theaudiodb.com/api/v1/json";
+export const TADB_API_KEY = "2";
 
-export const BASE_URL = "https://www.theaudiodb.com/api/v1/json";
-export const API_KEY = "2";
+// --- MusicBrainz constants ---
+export const MB_BASE_URL = "https://musicbrainz.org/ws/2";
+export const MB_USER_AGENT = "music-playlist-manager/1.0 (dev@yourdomain.com)";
+
+// MusicBrainz limit is 1 request per second
+// Ensure we do not exceed this rate
+let lastMBRequestTime = 0;
+async function throttleMusicBrainz() {
+  const now = Date.now();
+  const wait = Math.max(0, 1100 - (now - lastMBRequestTime));
+  if (wait > 0) await new Promise(res => setTimeout(res, wait));
+  lastMBRequestTime = Date.now();
+}
 
 /**
  * Search for artists by name.


### PR DESCRIPTION
## Summary

Implements the hybrid API layer for the music playlist manager.  
Adds all functions needed to interact with both **MusicBrainz** (for homepage artists) and **TheAudioDB** (for artist, album, track, and global search data).  
This is **Phase 1** of the migration to a hybrid data approach.

---

## Changes

### 🧠 MusicBrainz Integration
- Added `MUSICBRAINZ_API` constants.
- Added `throttle` utility to respect MusicBrainz rate limits.
- Added `getHomeArtistsMusicBrainz` to fetch homepage artists by genre.

### 🎧 TheAudioDB Integration
- Added `getArtistByName_TheAudioDB` to search for an artist by name.
- Updated/added `fetchAlbumsByArtistId` to fetch albums for a TheAudioDB artist ID (with caching).
- Added `fetchTracksByAlbumId` to fetch tracks for a given album.
- Added `searchAllTheAudioDB` to run 3 parallel TheAudioDB searches:
  - Artist
  - Album
  - Track