### PR TITLE
feat: Wire app.js to updated api.js: fetch albums by artist name for broader results

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,14 @@
       </section>
 
       <section id="albums" aria-live="polite">
-        Albums will appear here in Phase 2.
+        Albums
       </section>
+
+      <section id="tracks-section" style="display: none;">
+        <h3>Tracks</h3>
+        <div id="tracks-container"></div>
+      </section>
+
         <!-- Phase 4: Playlist Management -->
   <section id="playlists">
     <h2>Playlists</h2>


### PR DESCRIPTION
## Summary

This PR updates the album fetching logic to use TheAudioDB’s `searchalbum.php?s=artistName` endpoint instead of fetching by artist ID.  
This change yields more comprehensive album results for each artist—whether selecting a popular artist or searching by name—and updates the wiring between `app.js` and `api.js` accordingly.

---

## Changes

- Added `fetchAlbumsByArtistName` to `api.js` to fetch albums using the artist’s name.  
- Updated all album-fetching logic in `app.js` to call `fetchAlbumsByArtistName` instead of the previous artist-ID–based function.  
- Updated imports in `app.js` to reference the new `fetchAlbumsByArtistName`.  
- Ensured both homepage artist selection and manual artist search now return a broader set of albums.  
- Minor consistency tweaks in `index.html` (where applicable).

